### PR TITLE
Reset attributes at end, emit newline before prompt.

### DIFF
--- a/main.go
+++ b/main.go
@@ -59,11 +59,12 @@ func main() {
 	go func() {
 		<-c
 		time.Sleep(time.Millisecond * 250)
-		tm.Clear()                                    // Clear screen
-		tm.MoveCursor(1, 1)                           // Reset cursor
-		tm.Print("\033[?25hhttps://github.com/ak-tr") // Show cursor
-		tm.Flush()                                    // Mandatory flush
-		os.Exit(0)                                    // Exit
+		tm.Clear()                                      // Clear screen
+		tm.Print("\033[0m")                             // Reset attributes
+		tm.MoveCursor(1, 1)                             // Reset cursor
+		tm.Println("\033[?25hhttps://github.com/ak-tr") // Show cursor
+		tm.Flush()                                      // Mandatory flush
+		os.Exit(0)                                      // Exit
 	}()
 
 	// Print escape code to hide cursor


### PR DESCRIPTION
Hi, I played with your program, and noticed it left my terminal in a different state.  This fixes it for me on OSX Terminal.app.  Haven't tested others, but I would expect it to be common, unless goterm has some reset logic which is failing in my case.

Also put a newline after the URL so that the URL doesn't run on into the prompt.

[Also, apologies if my pull request is wrong.  First pull request on github :-).]